### PR TITLE
feat: add support for gpt-5 models

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,7 +201,7 @@ data:
 
 ### Custom Models
 Enter any model name in the "Custom Model" field:
-- OpenAI: `gpt-4-0125-preview`
+ - OpenAI: `gpt-5-mini`
 - Anthropic: `claude-3-opus-20240229`
 - OpenRouter: `anthropic/claude-3-opus`
 - Gemini: `gemini-pro-vision`

--- a/custom_components/ai_agent_ha/agent.py
+++ b/custom_components/ai_agent_ha/agent.py
@@ -11,7 +11,7 @@ ai_agent_ha:
   local_url: "http://localhost:11434/api/generate"  # Required for local models
   # Model configuration (optional, defaults will be used if not specified)
   models:
-    openai: "gpt-3.5-turbo"  # or "gpt-4", "gpt-4-turbo", etc.
+    openai: "gpt-5-mini"  # or "gpt-5", "gpt-4o", etc.
     llama: "Llama-4-Maverick-17B-128E-Instruct-FP8"
     gemini: "gemini-1.5-flash"  # or "gemini-1.5-pro", "gemini-1.0-pro", etc.
     openrouter: "openai/gpt-4o"  # or any model available on OpenRouter
@@ -420,10 +420,15 @@ class OpenAIClient(BaseAIClient):
         # Models that require max_completion_tokens instead of max_tokens
         completion_token_models = ["o3-mini", "o3", "o1-mini", "o1-preview", "o1"]
 
+        # Models that use max_output_tokens
+        output_token_models = ["gpt-4o", "gpt-4.1", "gpt-5"]
+
         # Check if the model name contains any of the newer model identifiers
         model_lower = self.model.lower()
         if any(model_id in model_lower for model_id in completion_token_models):
             return "max_completion_tokens"
+        if any(model_id in model_lower for model_id in output_token_models):
+            return "max_output_tokens"
         return "max_tokens"
 
     def _is_restricted_model(self):

--- a/custom_components/ai_agent_ha/config_flow.py
+++ b/custom_components/ai_agent_ha/config_flow.py
@@ -62,6 +62,8 @@ AVAILABLE_MODELS = {
         "gpt-4-turbo",
         "gpt-4o",
         "gpt-4o-mini",
+        "gpt-5",
+        "gpt-5-mini",
         "o1-preview",
         "o1-mini",
     ],
@@ -72,6 +74,8 @@ AVAILABLE_MODELS = {
         "gemini-2.0-flash-exp",
     ],
     "openrouter": [
+        "openai/gpt-5",
+        "openai/gpt-5-mini",
         "openai/gpt-4o",
         "openai/gpt-4-turbo",
         "openai/gpt-3.5-turbo",

--- a/tests/test_ai_agent_ha/test_agent_clients.py
+++ b/tests/test_ai_agent_ha/test_agent_clients.py
@@ -77,10 +77,14 @@ class TestOpenAIClient:
             # Test newer models
             client_o3 = OpenAIClient("test-token", "o3-mini")
             assert client_o3._get_token_parameter() == "max_completion_tokens"
-            
+
             # Test older models
             client_gpt = OpenAIClient("test-token", "gpt-3.5-turbo")
             assert client_gpt._get_token_parameter() == "max_tokens"
+
+            # Test gpt-5 models
+            client_gpt5 = OpenAIClient("test-token", "gpt-5-mini")
+            assert client_gpt5._get_token_parameter() == "max_output_tokens"
             
         except ImportError:
             pytest.skip("OpenAIClient not available")


### PR DESCRIPTION
## Summary
- add GPT-5 and GPT-5-mini to available OpenAI and OpenRouter model lists
- handle new GPT families in OpenAI client token parameter selection
- document GPT-5 models and extend tests

## Testing
- `pytest -q` *(fails: module 'custom_components' has no attribute 'ai_agent_ha'; KeyError in dashboard templates tests)*

------
https://chatgpt.com/codex/tasks/task_e_689f8d8073f0832290779b7c826e914f